### PR TITLE
Tickets/dm 33252

### DIFF
--- a/doc/commandStatus.md
+++ b/doc/commandStatus.md
@@ -23,6 +23,8 @@ This enum is defined in the `ts_rotator_controller` or `ts_hexapod_controller`.
 3. CSC issues a command when the graphical user interface (GUI) has control.
 (The GUI will not see this because the GUI takes control from CSC whenever it issues a command.)
 
+Note: The GUI can always take the control from CSC.
+
 ## Command Result
 
 The controller will report the result of command execution to the client.

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,5 +1,12 @@
 # Version History
 
+0.1.1
+
+- Replace the `printf()` with `syslog()` in `tcpServer.c`, `circular_buffer.c`, and `configPxi.c`.
+- Add the `cmdTlmServer.c`.
+This tries to unify the command server codes of GUI and CSC in `ts_rotator_controller` and `ts_hexapod_controller`.
+The support of telemetry part will be done in DM-33310, which will test the use of single socket for command and telemetry.
+
 0.1.0
 
 - Initial migration of the common codes from `ts_rotator_controller`.

--- a/include/interface/cmdTlmServer.h
+++ b/include/interface/cmdTlmServer.h
@@ -1,0 +1,96 @@
+#ifndef CMDTLMSERVER_H
+#define CMDTLMSERVER_H
+
+#include <stdbool.h>
+#include <pthread.h>
+#include <glib.h>
+#include <mqueue.h>
+
+#include "circular_buffer.h"
+
+typedef struct _serverInfo {
+    // Pointer of the server name
+    char *pName;
+    // Timeout for blocking call in millisecond. If -1, means never timeout.
+    int timeout;
+    // Size of the telemetry message in byte. If there are multiple telemetry
+    // structures, use the biggest size.
+    unsigned int sizeMsgTlm;
+    // Socket to listen to the connection request
+    int socketListen;
+    // Socket to connect to the TCP/IP client
+    int socketConnect;
+    // Thread to run the server
+    pthread_t thread;
+    // Is started to listen to the command and write the telemetry or not.
+    // This value is set to be true when the thread is ready, false when the
+    // software is ready to close the server.
+    bool isStart;
+    // Server status with the enum 'ServerStatus'
+    int serverStatus;
+    // Pointer of the name of command status queue
+    char *pQueueNameCmdStatus;
+    // Message queue of the command status
+    mqd_t msgQueueCmdStatus;
+    // Pointer of the command status used in message queue
+    gpointer *pMsgCmdStatus;
+    // Pointer of the name of telemetry queue
+    char *pQueueNameTlm;
+    // Message queue of the telemetry
+    mqd_t msgQueueTlm;
+    // Pointer of the telemetry message in message queue
+    gpointer *pMsgTlm;
+    // Is the commander or not
+    bool isCommander;
+    // Command buffer to write the new command
+    cbuf_handle_t cmdMsgBuffer;
+} serverInfo_t;
+
+typedef enum {
+    // TCP/IP server is disconnected with the TCP/IP client
+    ServerStatus_Disconnected = 1,
+    // TCP/IP server is connected with the TCP/IP client
+    ServerStatus_Connected = 2,
+    // TCP/IP server exits
+    ServerStatus_Exit = 3,
+} ServerStatus;
+
+// Initialize the server.
+// The user needs to provide the following inputs:
+// - pName: Pointer of the server name
+// - timeout: Timeout for blocking call in millisecond. If the value is <=0,
+//            it will be reset to be -1 internally, which means never timeout.
+// - sizeMsgTlm: Size of the telemetry message in byte.
+// - port: Port to listen to the connection request.
+// - maxNumQueueTlm: Maximum number of telemetry messages that can be queued for
+//                   send at once.
+// - cmdMsgBuffer: Command buffer to write the new commands.
+// The server imformation will be put in 'pServerInfo'.
+// Return 0 if success, otherwise, return -1.
+int cmdTlmServer_init(serverInfo_t *pServerInfo, char *pName, int timeout,
+                      unsigned int sizeMsgTlm, int port, long maxNumQueueTlm,
+                      cbuf_handle_t cmdMsgBuffer);
+
+// Run the server in a new thread.
+// Return 0 if success, otherwise, return -1.
+int cmdTlmServer_runInNewThread(serverInfo_t *pServerInfo);
+
+// Basic close of the server. This will close the sockets and free the allocated
+// memory.
+void cmdTlmServer_basicClose(serverInfo_t *pServerInfo);
+
+// Close the server thoroughly. This is used in the shutdown process.
+void cmdTlmServer_close(serverInfo_t *pServerInfo);
+
+// Sent the command status to message queue with the inputs of server
+// information, counter, command status (enum: CmdStatus), estimated duration of
+// command in second, and reason if the command failed (put "" if nothing to
+// report). If "reason" is longer than the buffer defined in
+// commandStatusStructure_t, it will be truncated to fit.
+// Return 0 if success, otherwise, return -1.
+int cmdTlmServer_sendCmdStatusToMsgQueue(serverInfo_t *pServerInfo,
+                                         unsigned int counter,
+                                         unsigned int cmdStatus,
+                                         double duration, const char *reason);
+
+#endif // CMDTLMSERVER_H

--- a/include/interface/cmdTlmServer.h
+++ b/include/interface/cmdTlmServer.h
@@ -30,13 +30,15 @@ typedef struct _serverInfo {
     bool isReady;
     // Server status with the enum 'ServerStatus'
     int serverStatus;
-    // Pointer to the name of command status queue
+    // Pointer to the name of command status queue. This is required by
+    // mq_open() to identify the queue.
     char *pQueueNameCmdStatus;
     // Message queue of the command status
     mqd_t msgQueueCmdStatus;
     // Pointer to the command status used in message queue
     gpointer *pMsgCmdStatus;
-    // Pointer to the name of telemetry queue
+    // Pointer to the name of telemetry queue. This is required by mq_open()
+    // to identify the queue.
     char *pQueueNameTlm;
     // Message queue of the telemetry
     mqd_t msgQueueTlm;

--- a/include/interface/commandStructure.h
+++ b/include/interface/commandStructure.h
@@ -48,12 +48,12 @@ typedef struct __attribute__((__packed__)) _commandStatusStructure {
 } commandStatusStructure_t;
 
 typedef enum {
-    // Controller internal use
-    Commander_Self = 1,
     // Graphical user interface
-    Commander_GUI = 2,
+    Commander_GUI = 1,
     // Commandable SAL component
-    Commander_CSC = 3,
+    Commander_CSC = 2,
+    // Controller internal use
+    Commander_Self = 3,
 } Commander;
 
 typedef enum {

--- a/include/interface/commandStructure.h
+++ b/include/interface/commandStructure.h
@@ -52,7 +52,9 @@ typedef enum {
     Commander_GUI = 1,
     // Commandable SAL component
     Commander_CSC = 2,
-    // Controller internal use
+    // Controller internal use. This is used in the hexapod controller code to
+    // hack the Simulink model. This value should be removed after fixing the
+    // hexapod Simulink model.
     Commander_Self = 3,
 } Commander;
 

--- a/include/interface/tcpServer.h
+++ b/include/interface/tcpServer.h
@@ -10,7 +10,7 @@
 // If error, return -1.
 int tcpServer_open(int family, int port, int maxConnection);
 
-// Accept the connection request with timeout millisecond. If timeout <= 0,
+// Accept the connection request with timeout in millisecond. If timeout <= 0,
 // means no timeout. In this case, the function will block forever until the
 // acceptance of a connection request.
 // Return the connected socket. If fail, return -1.

--- a/src/circular_buffer.c
+++ b/src/circular_buffer.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <syslog.h>
 
 #include "circular_buffer.h"
 
@@ -55,7 +56,7 @@ static void retreat_pointer(cbuf_handle_t cbuf) {
 // Hold the mutex lock.
 static inline void hold_lock(void) {
     if (pthread_mutex_lock(&lock) != 0) {
-        printf("Mutex lock has failed.\n");
+        syslog(LOG_ERR, "Mutex lock has failed.");
         exit(1);
     }
 }
@@ -63,7 +64,7 @@ static inline void hold_lock(void) {
 // Release the mutex lock.
 static inline void release_lock(void) {
     if (pthread_mutex_unlock(&lock) != 0) {
-        printf("Mutex unlock has failed.\n");
+        syslog(LOG_ERR, "Mutex unlock has failed.");
         exit(1);
     }
 }
@@ -92,7 +93,7 @@ cbuf_handle_t circular_buf_init(size_t size) {
 
     // Check the memory allocation is successful or not
     if ((buffer == NULL) || (cbuf == NULL)) {
-        printf("Memory not allocated.\n");
+        syslog(LOG_ERR, "Memory not allocated.");
         return NULL;
     }
 
@@ -101,7 +102,7 @@ cbuf_handle_t circular_buf_init(size_t size) {
     circular_buf_reset(cbuf);
 
     if (pthread_mutex_init(&lock, NULL) != 0) {
-        printf("Mutex init has failed.\n");
+        syslog(LOG_ERR, "Mutex init has failed.");
         exit(1);
     }
 
@@ -113,7 +114,7 @@ void circular_buf_free(cbuf_handle_t cbuf) {
     free(cbuf);
 
     if (pthread_mutex_destroy(&lock) != 0) {
-        printf("Mutex destroy has failed.\n");
+        syslog(LOG_ERR, "Mutex destroy has failed.");
         exit(1);
     }
 }

--- a/src/configPxi.c
+++ b/src/configPxi.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <yaml.h>
+#include <syslog.h>
 
 #include "utility.h"
 #include "configPxi.h"
@@ -43,7 +44,7 @@ char *configPxi_getSetting(const char *pFilePath, const char *pSettingName) {
         while (true) {
 
             if (yaml_parser_parse(&parser, &event) == 0) {
-                printf("Parser error: %d\n", parser.error);
+                syslog(LOG_ERR, "Parser error: %d", parser.error);
                 exit(EXIT_FAILURE);
             }
             type = event.type;

--- a/src/interface/cmdTlmServer.c
+++ b/src/interface/cmdTlmServer.c
@@ -59,8 +59,8 @@ void cmdTlmServer_close(serverInfo_t *pServerInfo) {
     syslog(LOG_NOTICE, "Closing the %s server.", pServerInfo->pName);
 
     int error = 0;
-    if (pServerInfo->isStart) {
-        pServerInfo->isStart = false;
+    if (pServerInfo->isReady) {
+        pServerInfo->isReady = false;
         error = pthread_join(pServerInfo->thread, NULL);
     }
 
@@ -85,7 +85,7 @@ static void cmdTlmServer_initServerInfo(serverInfo_t *pServerInfo, char *pName,
     pServerInfo->socketListen = -1;
     pServerInfo->socketConnect = -1;
 
-    pServerInfo->isStart = false;
+    pServerInfo->isReady = false;
     pServerInfo->serverStatus = ServerStatus_Disconnected;
 
     pServerInfo->pQueueNameCmdStatus = "";
@@ -281,7 +281,7 @@ static void *cmdTlmServer_run(void *pData) {
     serverInfo_t *pServerInfo = (serverInfo_t *)pData;
 
     // Wait until begins to run the server's job
-    while (!pServerInfo->isStart) {
+    while (!pServerInfo->isReady) {
         sleep(1);
     }
 
@@ -301,7 +301,7 @@ static void *cmdTlmServer_run(void *pData) {
 
     // Run the server
     int error;
-    while (pServerInfo->isStart) {
+    while (pServerInfo->isReady) {
 
         // New command message
         commandStreamStructure_t cmdMsg;
@@ -422,7 +422,7 @@ int cmdTlmServer_runInNewThread(serverInfo_t *pServerInfo) {
             pthread_exit(&pServerInfo->thread);
             return -1;
         }
-        pServerInfo->isStart = true;
+        pServerInfo->isReady = true;
     }
 
     return 0;

--- a/src/interface/cmdTlmServer.c
+++ b/src/interface/cmdTlmServer.c
@@ -1,0 +1,487 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <syslog.h>
+#include <errno.h>
+
+#include "utility.h"
+#include "tcpServer.h"
+#include "cmdTlmServer.h"
+
+void cmdTlmServer_basicClose(serverInfo_t *pServerInfo) {
+    // Close the sockets
+    if (pServerInfo->socketConnect != -1) {
+        tcpServer_close(pServerInfo->socketConnect);
+        pServerInfo->socketConnect = -1;
+    }
+
+    if (pServerInfo->socketListen != -1) {
+        tcpServer_close(pServerInfo->socketListen);
+        pServerInfo->socketListen = -1;
+    }
+
+    // Close the message queues
+    // Note that the order is reversed compared with the
+    // cmdTlmServer_prepareMsgQueue()
+    if (pServerInfo->pMsgTlm != NULL) {
+        g_free(pServerInfo->pMsgTlm);
+        pServerInfo->pMsgTlm = NULL;
+
+        mq_close(pServerInfo->msgQueueTlm);
+        mq_unlink(pServerInfo->pQueueNameTlm);
+    }
+
+    if (strncmp(pServerInfo->pQueueNameTlm, "", 1) != 0) {
+        free(pServerInfo->pQueueNameTlm);
+        pServerInfo->pQueueNameTlm = "";
+    }
+
+    if (pServerInfo->pMsgCmdStatus != NULL) {
+        g_free(pServerInfo->pMsgCmdStatus);
+        pServerInfo->pMsgCmdStatus = NULL;
+
+        mq_close(pServerInfo->msgQueueCmdStatus);
+        mq_unlink(pServerInfo->pQueueNameCmdStatus);
+    }
+
+    if (strncmp(pServerInfo->pQueueNameCmdStatus, "", 1) != 0) {
+        free(pServerInfo->pQueueNameCmdStatus);
+        pServerInfo->pQueueNameCmdStatus = "";
+    }
+}
+
+void cmdTlmServer_close(serverInfo_t *pServerInfo) {
+    syslog(LOG_NOTICE, "Closing the %s server.", pServerInfo->pName);
+
+    int error = 0;
+    if (pServerInfo->isStart) {
+        pServerInfo->isStart = false;
+        error = pthread_join(pServerInfo->thread, NULL);
+    }
+
+    if (error != 0) {
+        syslog(LOG_ERR, "Failed the waiting of thread in the %s server.",
+               pServerInfo->pName);
+    }
+
+    cmdTlmServer_basicClose(pServerInfo);
+}
+
+// Initialize the server information with the server name, timeout, size of
+// telemetry message in byte, and the command buffer.
+static void cmdTlmServer_initServerInfo(serverInfo_t *pServerInfo, char *pName,
+                                        int timeout, unsigned int sizeMsgTlm,
+                                        cbuf_handle_t cmdMsgBuffer) {
+    pServerInfo->pName = pName;
+    // Use the -1 instead if the input timeout is <= 0
+    pServerInfo->timeout = (timeout <= 0) ? -1 : timeout;
+    pServerInfo->sizeMsgTlm = sizeMsgTlm;
+
+    pServerInfo->socketListen = -1;
+    pServerInfo->socketConnect = -1;
+
+    pServerInfo->isStart = false;
+    pServerInfo->serverStatus = ServerStatus_Disconnected;
+
+    pServerInfo->pQueueNameCmdStatus = "";
+    pServerInfo->msgQueueCmdStatus = (mqd_t)(-1);
+    pServerInfo->pMsgCmdStatus = NULL;
+
+    pServerInfo->pQueueNameTlm = "";
+    pServerInfo->msgQueueTlm = (mqd_t)(-1);
+    pServerInfo->pMsgTlm = NULL;
+
+    pServerInfo->isCommander = false;
+
+    pServerInfo->cmdMsgBuffer = cmdMsgBuffer;
+}
+
+// Generate the name of message queue with the base name and identifier.
+// Return the name.
+static char *cmdTlmServer_genNameMsgQueue(char *pNameBase, int identifier) {
+    // Allocate the enough size of string buffer (10 is a random chosen value)
+    char str[10];
+    sprintf(str, "%d", identifier);
+    return joinStr(pNameBase, str);
+}
+
+// Create the message queue (non-blocking) with the maximum number of message,
+// message size in byte, and queue's name.
+// Return the message queue.
+static mqd_t cmdTlmServer_createMsgQueue(long maxNumMsg, long sizeMsg,
+                                         char *pName) {
+    struct mq_attr attr;
+    attr.mq_flags = O_NONBLOCK;
+    attr.mq_maxmsg = maxNumMsg;
+    attr.mq_msgsize = sizeMsg;
+    return mq_open(pName, O_CREAT | O_RDWR | O_NONBLOCK, 0, &attr);
+}
+
+// Prepare the message queues with an identifier used to differentiate
+// different queue messages. User also needs to provide the maximum number of
+// element in telemetry queue.
+// Return 0 if success, otherwise, return -1.
+static int cmdTlmServer_prepareMsgQueue(serverInfo_t *pServerInfo,
+                                        int identifier, long maxNumQueueTlm) {
+    // Generate the names of message queues
+    pServerInfo->pQueueNameCmdStatus =
+        cmdTlmServer_genNameMsgQueue("/queueCmdStatus", identifier);
+    pServerInfo->pQueueNameTlm =
+        cmdTlmServer_genNameMsgQueue("/queueTlm", identifier);
+
+    // Message queue of comomand status
+
+    // Note that the value of 4 is a random number. I expect there will be only
+    // 1 in the real running.
+    // The value here is just by try-and-error. If this value is too big, the
+    // kernel will reject it for the memory allocation.
+    // It is noted that the kernel will restrict the allocated memory for the
+    // message queue. Therefore, this value can not be too big.
+    pServerInfo->msgQueueCmdStatus =
+        cmdTlmServer_createMsgQueue(4, (long)sizeof(commandStatusStructure_t),
+                                    pServerInfo->pQueueNameCmdStatus);
+    if (pServerInfo->msgQueueCmdStatus == (mqd_t)(-1)) {
+        syslog(LOG_ERR, "Failed to create the message queue of command status "
+                        "in %s server.",
+               pServerInfo->pName);
+        return -1;
+    }
+
+    // Allocate the memory of message queue of command status
+    pServerInfo->pMsgCmdStatus =
+        g_malloc0_n((gsize)sizeof(commandStatusStructure_t), 2);
+
+    // Message queue of telemetry
+    pServerInfo->msgQueueTlm = cmdTlmServer_createMsgQueue(
+        maxNumQueueTlm, pServerInfo->sizeMsgTlm, pServerInfo->pQueueNameTlm);
+    if (pServerInfo->msgQueueTlm == (mqd_t)(-1)) {
+        syslog(LOG_ERR,
+               "Failed to create the message queue of telemetry in %s server.",
+               pServerInfo->pName);
+        return -1;
+    }
+
+    // Allocate the memory of message queue of telemetry
+    pServerInfo->pMsgTlm = g_malloc0_n((gsize)pServerInfo->sizeMsgTlm, 2);
+
+    return 0;
+}
+
+// Receive the message with a timeout value (in millisecond). The received
+// message will be written to the memory pointed to by pCmdMsg.
+// Return the error status or the received number of byte.
+// If the return value < 0, it means the timeout from poll() or error from
+// poll() or recv().
+// Note. If we do not set the timeout when using the recv(), the server may not
+// be able to close this thread because the recv() is a blocking call.
+static int cmdTlmServer_recv(commandStreamStructure_t *pCmdMsg,
+                             struct pollfd *pFds, int timeout) {
+
+    int numEvent = poll(pFds, 1, timeout);
+    if (numEvent <= 0) {
+        // error (-1) or timeout (0)
+        return -1;
+    }
+
+    return recv(pFds->fd, pCmdMsg, sizeof(commandStreamStructure_t), 0);
+}
+
+// Send the last command status in message queue if any.
+// Return 0 if sending successfully. Else, -1.
+static int cmdTlmServer_sendLastCmdStateInMsgQueue(serverInfo_t *pServerInfo) {
+    int bytesReceived = mq_receive(pServerInfo->msgQueueCmdStatus,
+                                   (char *)pServerInfo->pMsgCmdStatus,
+                                   sizeof(commandStatusStructure_t), NULL);
+
+    // Send the message only when there is the available data.
+    // Writing to a closed socket will raise SIGPIPE.
+    // For the refereces of this and how to avoid, follow:
+    // https://newbedev.com/how-to-prevent-sigpipes-or-handle-them-properly
+    // https://stackoverflow.com/questions/26752649/so-nosigpipe-was-not-declared
+    // https://stackoverflow.com/questions/19172804/crash-when-sending-data-without-connection-via-socket-in-linux?rq=1
+    int error = 0;
+    if (bytesReceived > 0) {
+        error = send(pServerInfo->socketConnect, pServerInfo->pMsgCmdStatus,
+                     bytesReceived, MSG_NOSIGNAL);
+        if (error < 0) {
+            // Return if the connection is broken
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+// Close the connection with the TCP/IP client. This function will reset the
+// file descriptor of 'pollfd' structure. The server will be put into the
+// Disconnected state and wait for the new connection request.
+static void cmdTlmServer_closeConn(serverInfo_t *pServerInfo,
+                                   struct pollfd *pFds) {
+
+    syslog(LOG_NOTICE, "Connection socket being reset in %s server.",
+           pServerInfo->pName);
+    tcpServer_close(pServerInfo->socketConnect);
+
+    pServerInfo->socketConnect = -1;
+    pFds->fd = -1;
+
+    pServerInfo->serverStatus = ServerStatus_Disconnected;
+    syslog(LOG_NOTICE, "The state of %s server is disconnected.",
+           pServerInfo->pName);
+}
+
+// Check the command message (pCmdMsg) is valid or not. The status of command
+// will be filled in pCmdStatus if the command is invalid. This function will
+// check the commander as well.
+// Return true if valid. Else, false.
+static bool cmdTlmServer_isCmdValid(commandStatusStructure_t *pCmdStatus,
+                                    commandStreamStructure_t *pCmdMsg,
+                                    bool isCommander) {
+    char *reasonCmdFail = "";
+    bool isCmdValid = true;
+
+    // Check the commander is from CSC/GUI or not
+    if (isCmdValid && !((pCmdMsg->commander == Commander_GUI) ||
+                        (pCmdMsg->commander == Commander_CSC))) {
+        reasonCmdFail = "Invalid commander";
+        isCmdValid = false;
+    }
+
+    // Check the CSC is the commander or not
+    // For the GUI, it can always give the command
+    if (isCmdValid && !isCommander && (pCmdMsg->commander == Commander_CSC)) {
+        reasonCmdFail = "Is not the commander";
+        isCmdValid = false;
+    }
+
+    if (!isCmdValid) {
+        pCmdStatus->header.frameId = FrameId_CmdStatus;
+        pCmdStatus->header.counter = pCmdMsg->counter;
+        pCmdStatus->cmdStatus = CmdStatus_NotOK;
+        pCmdStatus->duration = 0;
+        strncpy(&pCmdStatus->reason[0], reasonCmdFail,
+                LENGTH_CMD_STATUS_REASON);
+        pCmdStatus->reason[LENGTH_CMD_STATUS_REASON - 1] = '\0';
+    }
+
+    return isCmdValid;
+}
+
+// Run the server.
+// Note: The data types of input and output are required for pthread_create().
+// The input needs to cast to the correct data type.
+static void *cmdTlmServer_run(void *pData) {
+
+    // Get the server information
+    serverInfo_t *pServerInfo = (serverInfo_t *)pData;
+
+    // Wait until begins to run the server's job
+    while (!pServerInfo->isStart) {
+        sleep(1);
+    }
+
+    // Loop delay time
+    // 50 milliseconds (= 20 Hz)
+    struct timespec ts50;
+    ts50.tv_nsec = 50000000;
+    ts50.tv_sec = 0;
+
+    // Use poll() for the connected socket
+    struct pollfd fds;
+    fds.events = POLLIN;
+
+    // Wait for the connection to the server
+    syslog(LOG_NOTICE, "Waiting for the connection request in %s server.",
+           pServerInfo->pName);
+
+    // Run the server
+    int error;
+    while (pServerInfo->isStart) {
+
+        // New command message
+        commandStreamStructure_t cmdMsg;
+        commandStatusStructure_t cmdStatus;
+
+        // State machine to deal with the connection/disconnection with
+        // TCP/IP client
+        switch (pServerInfo->serverStatus) {
+
+        // Look for the connection with TCP/IP client
+        case ServerStatus_Disconnected:
+            // Wait for the connection request
+            pServerInfo->socketConnect = tcpServer_accept(
+                pServerInfo->socketListen, pServerInfo->timeout);
+            if (pServerInfo->socketConnect == -1) {
+                break;
+            } else {
+                pServerInfo->serverStatus = ServerStatus_Connected;
+
+                syslog(LOG_NOTICE,
+                       "The state of %s server is connected. socket = %d.",
+                       pServerInfo->pName, pServerInfo->socketConnect);
+
+                // Make use of poll() to receive the message
+                fds.fd = pServerInfo->socketConnect;
+            }
+            break;
+
+        // Connected with the TCP/IP client, look for commands
+        case ServerStatus_Connected:
+
+            // Reply the last command status from commanding.c
+            error = cmdTlmServer_sendLastCmdStateInMsgQueue(pServerInfo);
+
+            // We were connected but the connection has been broken
+            if (error < 0) {
+                cmdTlmServer_closeConn(pServerInfo, &fds);
+                break;
+            }
+
+            // Check the new command
+            error = cmdTlmServer_recv(&cmdMsg, &fds, pServerInfo->timeout);
+
+            // Ignore the timeout or error
+            if (error < 0) {
+                break;
+            }
+
+            // Client closes the connection
+            if (error == 0) {
+                cmdTlmServer_closeConn(pServerInfo, &fds);
+                break;
+            }
+
+            // Check the command is valid or not
+            bool isCmdValid = cmdTlmServer_isCmdValid(&cmdStatus, &cmdMsg,
+                                                      pServerInfo->isCommander);
+
+            if (isCmdValid) {
+                // Write command to command message buffer
+                if (circular_buf_put(pServerInfo->cmdMsgBuffer, cmdMsg)) {
+                    syslog(LOG_NOTICE,
+                           "The command message is overwritten in %s server.",
+                           pServerInfo->pName);
+                }
+            }
+
+            // Send the NotOK message to client if needed
+
+            // Writing to a closed socket will raise SIGPIPE. Check
+            // cmdTlmServer_sendLastCmdStateInMsgQueue() for the details
+            // (references) that how to avoid the termination signal
+            if (!isCmdValid) {
+                error = send(pServerInfo->socketConnect, &cmdStatus,
+                             sizeof(commandStatusStructure_t), MSG_NOSIGNAL);
+            } else {
+                error = 0;
+            }
+
+            // We were connected but the connection has been broken
+            if (error < 0) {
+                cmdTlmServer_closeConn(pServerInfo, &fds);
+                break;
+            }
+
+            break;
+
+        default:
+            break;
+        }
+
+        // Give other functions a chance to run
+        nanosleep(&ts50, NULL);
+    }
+
+    cmdTlmServer_basicClose(pServerInfo);
+    pServerInfo->serverStatus = ServerStatus_Exit;
+
+    return 0;
+}
+
+int cmdTlmServer_runInNewThread(serverInfo_t *pServerInfo) {
+    int error = pthread_create(&pServerInfo->thread, NULL, cmdTlmServer_run,
+                               (void *)pServerInfo);
+    struct sched_param param;
+    if (error != 0) {
+        syslog(LOG_ERR, "Failed to create the thread in %s server.",
+               pServerInfo->pName);
+        return -1;
+    } else {
+        // Set priority of this thread
+        param.sched_priority = sched_get_priority_max(SCHED_OTHER);
+        if ((error = pthread_setschedparam(pServerInfo->thread, SCHED_OTHER,
+                                           &param)) != 0) {
+            syslog(LOG_ERR, "Can't initiaze the thread priority in %s server.",
+                   pServerInfo->pName);
+
+            pthread_exit(&pServerInfo->thread);
+            return -1;
+        }
+        pServerInfo->isStart = true;
+    }
+
+    return 0;
+}
+
+int cmdTlmServer_init(serverInfo_t *pServerInfo, char *pName, int timeout,
+                      unsigned int sizeMsgTlm, int port, long maxNumQueueTlm,
+                      cbuf_handle_t cmdMsgBuffer) {
+    // Initialize the server information
+    cmdTlmServer_initServerInfo(pServerInfo, pName, timeout, sizeMsgTlm,
+                                cmdMsgBuffer);
+
+    // Create the socket to listen the connection request
+    // Only allow a single connection
+    // Hard-code to use the IPv4 at this moment to simplify the implementation
+    pServerInfo->socketListen = tcpServer_open(AF_INET, port, 1);
+    if (pServerInfo->socketListen == -1) {
+        syslog(LOG_ERR,
+               "Failed to create the socket to listen the connection request "
+               "in %s server.",
+               pName);
+
+        return -1;
+    }
+
+    syslog(LOG_NOTICE, "Listening socket is opened at port %d for %s server.",
+           port, pName);
+
+    // Prepare the message queues
+    int error = cmdTlmServer_prepareMsgQueue(pServerInfo, port, maxNumQueueTlm);
+    if (error == -1) {
+        cmdTlmServer_basicClose(pServerInfo);
+        return -1;
+    }
+
+    return 0;
+}
+
+int cmdTlmServer_sendCmdStatusToMsgQueue(serverInfo_t *pServerInfo,
+                                         unsigned int counter,
+                                         unsigned int cmdStatus,
+                                         double duration, const char *reason) {
+
+    // Fill the command status
+    commandStatusStructure_t cmdStatusSend;
+    cmdStatusSend.header.frameId = FrameId_CmdStatus;
+    cmdStatusSend.header.counter = counter;
+    cmdStatusSend.cmdStatus = cmdStatus;
+    cmdStatusSend.duration = duration;
+
+    strncpy(&cmdStatusSend.reason[0], reason, LENGTH_CMD_STATUS_REASON);
+    cmdStatusSend.reason[LENGTH_CMD_STATUS_REASON - 1] = '\0';
+
+    // Send the message
+    int error = mq_send(pServerInfo->msgQueueCmdStatus, (char *)&cmdStatusSend,
+                        sizeof(commandStatusStructure_t), 0);
+    if (error < 0) {
+        syslog(LOG_ERR, "Fail to send the command status: %s", strerror(errno));
+    }
+
+    return error;
+}

--- a/src/interface/tcpServer.c
+++ b/src/interface/tcpServer.c
@@ -7,8 +7,9 @@
 #include <netdb.h>
 #include <string.h>
 #include <poll.h>
+#include <syslog.h>
 
-#include <tcpServer.h>
+#include "tcpServer.h"
 
 int tcpServer_open(int family, int port, int maxConnection) {
     // Modified from the chapter 11.4.7 in Computer Systems, A Programmer’s
@@ -113,7 +114,7 @@ int tcpServer_accept(int serverSocketDesc, int timeout) {
 
     // Print the connected IP
     char *ip = inet_ntoa(client.sin_addr);
-    printf("Get the connection from: %s.\n", ip);
+    syslog(LOG_NOTICE, "Get the connection from: %s.", ip);
 
     return socketConnect;
 }
@@ -131,7 +132,7 @@ bool tcpServer_isConnected(int socketDesc) {
     }
 
     if (error != 0) {
-        printf("Socket error: %s\n", strerror(error));
+        syslog(LOG_ERR, "Socket error: %s", strerror(error));
         return false;
     }
 
@@ -147,7 +148,7 @@ void tcpServer_close(int socketDesc) {
 int tcpServer_getSocketConnect(int family) {
     int socketDesc;
     if ((socketDesc = socket(family, SOCK_STREAM, 0)) < 0) {
-        printf("Socket creation error.\n");
+        syslog(LOG_NOTICE, "Socket creation error.");
         exit(1);
     }
 

--- a/src/interface/tcpServer.c
+++ b/src/interface/tcpServer.c
@@ -152,5 +152,7 @@ int tcpServer_getSocketConnect(int family) {
         exit(1);
     }
 
+    syslog(LOG_NOTICE, "Create the socket: %d.", socketDesc);
+
     return socketDesc;
 }

--- a/tests/interface/testCmdTlmServer.cpp
+++ b/tests/interface/testCmdTlmServer.cpp
@@ -163,7 +163,7 @@ TEST_F(CmdTlmServerTest, init) {
     EXPECT_NE(-1, serverInfo.socketListen);
     EXPECT_EQ(-1, serverInfo.socketConnect);
 
-    EXPECT_FALSE(serverInfo.isStart);
+    EXPECT_FALSE(serverInfo.isReady);
     EXPECT_EQ(ServerStatus_Disconnected, serverInfo.serverStatus);
 
     EXPECT_STREQ("/queueCmdStatus8888", serverInfo.pQueueNameCmdStatus);

--- a/tests/interface/testCmdTlmServer.cpp
+++ b/tests/interface/testCmdTlmServer.cpp
@@ -57,7 +57,8 @@ static void *startClient(void *pServerData) {
     EXPECT_EQ(cmdMsg.counter, cmdStatus.header.counter);
     EXPECT_EQ(CmdStatus_NotOK, cmdStatus.cmdStatus);
     EXPECT_DOUBLE_EQ(0, cmdStatus.duration);
-    EXPECT_STREQ("Invalid commander", cmdStatus.reason);
+    EXPECT_STREQ("Unrecognized commander; must be one of GUI or CSC",
+                 cmdStatus.reason);
 
     // Get the NotOK if not the commander
     cmdMsg.commander = Commander_CSC;
@@ -67,7 +68,7 @@ static void *startClient(void *pServerData) {
 
     EXPECT_EQ(sizeof(commandStatusStructure_t), msgSize);
     EXPECT_EQ(CmdStatus_NotOK, cmdStatus.cmdStatus);
-    EXPECT_STREQ("Is not the commander", cmdStatus.reason);
+    EXPECT_STREQ("The CSC is not the commander", cmdStatus.reason);
 
     // GUI can always give a command
     cmdMsg.commander = Commander_GUI;

--- a/tests/interface/testCmdTlmServer.cpp
+++ b/tests/interface/testCmdTlmServer.cpp
@@ -1,0 +1,255 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+#include <syslog.h>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "circular_buffer.h"
+#include "tcpServer.h"
+#include "cmdTlmServer.h"
+}
+
+volatile cbuf_handle_t cmdMsgBuffer;
+
+typedef struct _serverData {
+    serverInfo_t *pServerInfo;
+    struct sockaddr_in serverAddr;
+} serverData_t;
+
+// Start a command client and write commands.
+static void *startClient(void *pServerData) {
+    // Remap the input data
+    serverData_t serverData = *(serverData_t *)pServerData;
+    serverInfo_t *pServerInfo = serverData.pServerInfo;
+    struct sockaddr_in serverAddr = serverData.serverAddr;
+
+    // Do the connection
+    int socketDesc = tcpServer_getSocketConnect(serverAddr.sin_family);
+    if (connect(socketDesc, (struct sockaddr *)&serverAddr,
+                sizeof(serverAddr)) == -1) {
+        printf("Connection Failed.\n");
+        exit(1);
+    }
+
+    sleep(1);
+    EXPECT_EQ(ServerStatus_Connected, pServerInfo->serverStatus);
+
+    // Test the NotOK messages
+    commandStreamStructure_t cmdMsg;
+
+    // Write the command and wait for some time to let the command server get
+    // the message
+    // By adding one to the maximum of enum 'Commander', command should fail
+    cmdMsg.commander = Commander_CSC + 1;
+    cmdMsg.counter = 2;
+    cmdMsg.cmd = 1;
+    send(socketDesc, &cmdMsg, sizeof(cmdMsg), 0);
+
+    // Check to receive the NotOK from socket
+    commandStatusStructure_t cmdStatus;
+    int msgSize =
+        recv(socketDesc, &cmdStatus, sizeof(commandStatusStructure_t), 0);
+
+    EXPECT_EQ(sizeof(commandStatusStructure_t), msgSize);
+    EXPECT_EQ(FrameId_CmdStatus, cmdStatus.header.frameId);
+    EXPECT_EQ(cmdMsg.counter, cmdStatus.header.counter);
+    EXPECT_EQ(CmdStatus_NotOK, cmdStatus.cmdStatus);
+    EXPECT_DOUBLE_EQ(0, cmdStatus.duration);
+    EXPECT_STREQ("Invalid commander", cmdStatus.reason);
+
+    // Get the NotOK if not the commander
+    cmdMsg.commander = Commander_CSC;
+    send(socketDesc, &cmdMsg, sizeof(cmdMsg), 0);
+
+    msgSize = recv(socketDesc, &cmdStatus, sizeof(commandStatusStructure_t), 0);
+
+    EXPECT_EQ(sizeof(commandStatusStructure_t), msgSize);
+    EXPECT_EQ(CmdStatus_NotOK, cmdStatus.cmdStatus);
+    EXPECT_STREQ("Is not the commander", cmdStatus.reason);
+
+    // GUI can always give a command
+    cmdMsg.commander = Commander_GUI;
+    send(socketDesc, &cmdMsg, sizeof(cmdMsg), 0);
+
+    // Close the socket
+    tcpServer_close(socketDesc);
+    sleep(1);
+
+    EXPECT_EQ(ServerStatus_Disconnected, pServerInfo->serverStatus);
+
+    // Try the connection again
+    socketDesc = tcpServer_getSocketConnect(serverAddr.sin_family);
+    if (connect(socketDesc, (struct sockaddr *)&serverAddr,
+                sizeof(serverAddr)) == -1) {
+        printf("Connection Failed.\n");
+        exit(1);
+    }
+
+    sleep(1);
+    EXPECT_EQ(ServerStatus_Connected, pServerInfo->serverStatus);
+
+    // Put the server into the commander and write a command
+    pServerInfo->isCommander = true;
+
+    cmdMsg.commander = Commander_CSC;
+    send(socketDesc, &cmdMsg, sizeof(cmdMsg), 0);
+
+    // Simulate to send the last command status from controller
+    char *reason = "A reason";
+    double duration = 1.2;
+    cmdTlmServer_sendCmdStatusToMsgQueue(pServerInfo, cmdMsg.counter,
+                                         CmdStatus_OK, duration, reason);
+
+    // Check to receive the command status
+    msgSize = recv(socketDesc, &cmdStatus, sizeof(commandStatusStructure_t), 0);
+
+    EXPECT_EQ(sizeof(commandStatusStructure_t), msgSize);
+    EXPECT_EQ(FrameId_CmdStatus, cmdStatus.header.frameId);
+    EXPECT_EQ(cmdMsg.counter, cmdStatus.header.counter);
+    EXPECT_EQ(CmdStatus_OK, cmdStatus.cmdStatus);
+    EXPECT_DOUBLE_EQ(duration, cmdStatus.duration);
+    EXPECT_STREQ(reason, cmdStatus.reason);
+
+    // Close the server to release the resource
+    // Note that we do not want to close the 'socketDesc' first to simulate the
+    // real condition that the sever should be able to close the connection by
+    // itself.
+    cmdTlmServer_close(pServerInfo);
+    EXPECT_EQ(ServerStatus_Exit, pServerInfo->serverStatus);
+
+    // Close the connection in client to release the resource
+    tcpServer_close(socketDesc);
+    return 0;
+}
+
+struct CmdTlmServerTest : testing::Test {
+
+    const char *localhost = "127.0.0.1";
+
+    char *name = "cmdTlm";
+    int timeout = 100;
+    unsigned int sizeMsgTlm = 10;
+    int port = 8888;
+    long maxNumQueueTlm = 10;
+
+    serverInfo_t serverInfo;
+
+    CmdTlmServerTest() {
+        cmdMsgBuffer = circular_buf_init(2);
+
+        openlog("CmdTlmServer", LOG_CONS, LOG_SYSLOG);
+    }
+
+    ~CmdTlmServerTest() {
+        cmdTlmServer_close(&serverInfo);
+        circular_buf_free(cmdMsgBuffer);
+
+        closelog();
+    }
+};
+
+TEST_F(CmdTlmServerTest, init) {
+    int status = cmdTlmServer_init(&serverInfo, name, timeout, sizeMsgTlm, port,
+                                   maxNumQueueTlm, cmdMsgBuffer);
+
+    EXPECT_EQ(0, status);
+
+    EXPECT_STREQ(name, serverInfo.pName);
+    EXPECT_EQ(timeout, serverInfo.timeout);
+    EXPECT_EQ(sizeMsgTlm, serverInfo.sizeMsgTlm);
+
+    EXPECT_NE(-1, serverInfo.socketListen);
+    EXPECT_EQ(-1, serverInfo.socketConnect);
+
+    EXPECT_FALSE(serverInfo.isStart);
+    EXPECT_EQ(ServerStatus_Disconnected, serverInfo.serverStatus);
+
+    EXPECT_STREQ("/queueCmdStatus8888", serverInfo.pQueueNameCmdStatus);
+    EXPECT_STREQ("/queueTlm8888", serverInfo.pQueueNameTlm);
+
+    EXPECT_NE(nullptr, serverInfo.pMsgCmdStatus);
+    EXPECT_NE(nullptr, serverInfo.pMsgTlm);
+
+    EXPECT_FALSE(serverInfo.isCommander);
+}
+
+TEST_F(CmdTlmServerTest, initTimeoutZero) {
+    timeout = 0;
+    int status = cmdTlmServer_init(&serverInfo, name, timeout, sizeMsgTlm, port,
+                                   maxNumQueueTlm, cmdMsgBuffer);
+
+    EXPECT_EQ(0, status);
+
+    EXPECT_EQ(-1, serverInfo.timeout);
+}
+
+TEST_F(CmdTlmServerTest, sendCmdStatusToMsgQueue) {
+    cmdTlmServer_init(&serverInfo, name, timeout, sizeMsgTlm, port,
+                      maxNumQueueTlm, cmdMsgBuffer);
+
+    // Write a message of command status
+    unsigned int counter = 3;
+    unsigned int cmdStatus = CmdStatus_OK;
+    double duration = 1.2;
+    char *reason = "This is a reason";
+    int status = cmdTlmServer_sendCmdStatusToMsgQueue(
+        &serverInfo, counter, cmdStatus, duration, reason);
+
+    EXPECT_EQ(0, status);
+
+    // Receive the message of command status
+    size_t sizeCmdStatus = sizeof(commandStatusStructure_t);
+    commandStatusStructure_t cmdStatusRecv;
+    int bytesReceived = mq_receive(serverInfo.msgQueueCmdStatus,
+                                   (char *)&cmdStatusRecv, sizeCmdStatus, NULL);
+
+    EXPECT_EQ(sizeCmdStatus, bytesReceived);
+
+    EXPECT_EQ(FrameId_CmdStatus, cmdStatusRecv.header.frameId);
+    EXPECT_EQ(counter, cmdStatusRecv.header.counter);
+    EXPECT_EQ(cmdStatus, cmdStatusRecv.cmdStatus);
+    EXPECT_DOUBLE_EQ(duration, cmdStatusRecv.duration);
+    EXPECT_STREQ(reason, cmdStatusRecv.reason);
+}
+
+TEST_F(CmdTlmServerTest, runInNewThread) {
+
+    EXPECT_EQ(0, circular_buf_size(cmdMsgBuffer));
+
+    // Run the server
+    cmdTlmServer_init(&serverInfo, name, timeout, sizeMsgTlm, port,
+                      maxNumQueueTlm, cmdMsgBuffer);
+
+    int status = cmdTlmServer_runInNewThread(&serverInfo);
+    EXPECT_EQ(0, status);
+
+    // Set up the server address
+    // We only need to set the 's_addr' of 'sin_addr' based on:
+    // https://www.gta.ufrj.br/ensino/eel878/sockets/sockaddr_inman.html
+    struct sockaddr_in serverAddr;
+    serverAddr.sin_family = AF_INET;
+    serverAddr.sin_port = htons(port);
+    serverAddr.sin_addr.s_addr = inet_addr(localhost);
+
+    // Run the client in a new thread to simulate the use of code in controller
+    serverData_t serverData;
+    serverData.pServerInfo = &serverInfo;
+    serverData.serverAddr = serverAddr;
+
+    pthread_t threadClient;
+    int error =
+        pthread_create(&threadClient, NULL, startClient, (void *)&serverData);
+    if (error != 0) {
+        perror("Thread of TCP/IP client creation failed");
+        exit(1);
+    }
+
+    // Wait the thread
+    pthread_join(threadClient, NULL);
+    printf("Finish the waiting of client thread.\n");
+
+    // Check there should be two new commands in the buffer now
+    EXPECT_EQ(2, circular_buf_size(cmdMsgBuffer));
+}

--- a/tests/interface/testTcpServer.cpp
+++ b/tests/interface/testTcpServer.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <syslog.h>
 
 #include "gtest/gtest.h"
 
@@ -22,12 +23,16 @@ struct TcpServerTest : testing::Test {
         port = 8888;
         maxConnection = 1;
         socketListen = -1;
+
+        openlog("TcpServer", LOG_CONS, LOG_SYSLOG);
     }
 
     ~TcpServerTest() {
         if (socketListen >= 0) {
             tcpServer_close(socketListen);
         }
+
+        closelog();
     }
 };
 

--- a/tests/testCircularBuffer.cpp
+++ b/tests/testCircularBuffer.cpp
@@ -1,3 +1,5 @@
+#include <syslog.h>
+
 #include "gtest/gtest.h"
 
 extern "C" {
@@ -9,9 +11,17 @@ struct CircularBufferTest : testing::Test {
     int bufferSize = 5;
     cbuf_handle_t cbuf;
 
-    CircularBufferTest() { cbuf = circular_buf_init(bufferSize); }
+    CircularBufferTest() {
+        cbuf = circular_buf_init(bufferSize);
 
-    ~CircularBufferTest() { circular_buf_free(cbuf); }
+        openlog("CircularBuffer", LOG_CONS, LOG_SYSLOG);
+    }
+
+    ~CircularBufferTest() {
+        circular_buf_free(cbuf);
+
+        closelog();
+    }
 };
 
 TEST(CircularBuffer, circularBufInit) { EXPECT_EQ(NULL, circular_buf_init(0)); }

--- a/tests/testConfigPxi.cpp
+++ b/tests/testConfigPxi.cpp
@@ -1,5 +1,6 @@
 #include <sys/socket.h>
 #include <cstring>
+#include <syslog.h>
 
 #include "gtest/gtest.h"
 
@@ -15,6 +16,8 @@ struct ConfigPxiTest : testing::Test {
         testConfigFilePath =
             joinStr(getModulePath(), "/tests/testData/default.yaml");
         configPxi_setConfigFile(testConfigFilePath);
+
+        openlog("ConfigPxi", LOG_CONS, LOG_SYSLOG);
     }
 
     ~ConfigPxiTest() {
@@ -22,6 +25,8 @@ struct ConfigPxiTest : testing::Test {
         testConfigFilePath = NULL;
 
         configPxi_setConfigFile("");
+
+        closelog();
     }
 };
 


### PR DESCRIPTION
- Replace the `printf()` with `syslog()` in `tcpServer.c`, `circular_buffer.c`, and `configPxi.c`.
- Add the `cmdTlmServer.c`.
This tries to unify the command server codes of GUI and CSC in `ts_rotator_controller` and `ts_hexapod_controller`.
The support of telemetry part will be done in DM-33310, which will test the use of single socket for command and telemetry.