### PR TITLE
Change the sleep time in telemetry loop.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 
     agent {
         docker {
-            image 'lsstts/rotator_pxi:v0.3'
+            image 'lsstts/rotator_pxi:v0.4'
         }
     }
 

--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,5 +1,10 @@
 # Version History
 
+0.1.4
+
+- Change the telemetry loop to be 50 Hz instead of 20 Hz.
+This is to deal with the observed time delay on summit.
+
 0.1.3
 
 - Copy the `testCircularBufferThread.cpp` from `ts_rotator_controller`.

--- a/src/interface/cmdTlmServer.c
+++ b/src/interface/cmdTlmServer.c
@@ -350,14 +350,14 @@ static void *cmdTlmServer_sendTlmAndCmdStatus(void *pData) {
     serverInfo_t *pServerInfo = (serverInfo_t *)pData;
 
     // Loop delay time
-    // 50 milliseconds (= 20 Hz)
-    struct timespec ts50;
-    ts50.tv_nsec = 50000000;
-    ts50.tv_sec = 0;
+    // 20 milliseconds (= 50 Hz)
+    struct timespec ts20;
+    ts20.tv_nsec = 20000000;
+    ts20.tv_sec = 0;
 
     // Wait until begins to write the telemetry
     while (!pServerInfo->isReadyTlm) {
-        nanosleep(&ts50, NULL);
+        nanosleep(&ts20, NULL);
     }
 
     // Write the telemetry and command status
@@ -392,7 +392,7 @@ static void *cmdTlmServer_sendTlmAndCmdStatus(void *pData) {
             pServerInfo->isCloseConnDetected = true;
         }
 
-        nanosleep(&ts50, NULL);
+        nanosleep(&ts20, NULL);
     }
 
     return 0;


### PR DESCRIPTION
- Change the telemetry loop to be 50 Hz instead of 20 Hz.
This is to deal with the observed time delay on summit.