### PR TITLE
Fix the possible overflow.

### DIFF
--- a/doc/versionHistory.md
+++ b/doc/versionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+0.1.7
+
+- Fix the possible overflow of `joinStr()`.
+
 0.1.6
 
 - Improve the `logTlm.c` with 2 buffers to avoid the lost of data.

--- a/src/utility.c
+++ b/src/utility.c
@@ -22,7 +22,7 @@ char *joinStr(char *str1, char *str2) {
     char *strJoin = (char *)calloc(lengStrJoin, sizeof(char));
 
     strncpy(strJoin, str1, strlen(str1) + 1);
-    strncat(strJoin, str2, strlen(str2) + 1);
+    strncat(strJoin, str2, lengStrJoin - strlen(str1));
 
     return strJoin;
 }


### PR DESCRIPTION
- Fix the possible overflow of `joinStr()`.